### PR TITLE
Add default_metrics

### DIFF
--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -64,7 +64,7 @@ module "cw_logs_aggregator_rule_batch_jobs" {
 
   # Query settings
   log_group_name      = "/my/log/group"
-  query               = "stats sum(count) as count by job_name"
+  query               = "stats sum(count) as `\"count\"` by job_name"
   metric_name_prefix  = "batch-job"
   group_field         = "job_name"
   schedule_expression = "rate(5 minutes)"
@@ -115,7 +115,7 @@ Logs:
 Query:
 
 ```
-stats sum(processed) as processed, sum(success) as success, sum(failure) as failure
+stats sum(processed) as `"processed"`, sum(success) as `"success"`, sum(failure) as `"failure"`
 ```
 
 Query result:
@@ -210,7 +210,7 @@ Logs:
 Query:
 
 ```
-stats sum(processed) as processed, sum(success) as success, sum(failure) as failure by job_name
+stats sum(processed) as `"processed"`, sum(success) as `"success"`, sum(failure) as `"failure"` by job_name
 ```
 
 Query result:
@@ -314,7 +314,7 @@ Logs:
 Query:
 
 ```
-stats sum(processed) as processed by job_name
+stats sum(processed) as `"processed"` by job_name
 ```
 
 Query result:

--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -87,7 +87,7 @@ module "cw_logs_aggregator_rule_batch_jobs" {
 | `metric_name_prefix` | The common prefix appended to metric names. See the [Metrics](#metrics) section below. | `""` |
 | `group_field` | The field name that is used to group metrics. See the [Metrics](#metrics) section below. | `""` |
 | `default_field` | The field name that is not included in metric names. See the [Metrics](#metrics) section below. | `""` |
-| `default_metrics` | The default metrics posted when the corresponding metrics are missing. | `{}` |
+| `default_metrics` | The default metric values posted when the corresponding values are missing in query results. | `{}` |
 | `schedule_expression` | The schedule expression of the rule specifying the execution interval. Usually the execution interval is equal to the query interval. See [the document](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html) for the expression syntax. | |
 | `interval_in_minutes` | The interval of the query time range, in minutes. | |
 | `offset_in_minutes` | The offset of the query time range, in minutes. Usually this is the assumed maximum delay of logs. | `10` |

--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -87,7 +87,7 @@ module "cw_logs_aggregator_rule_batch_jobs" {
 | `metric_name_prefix` | The common prefix appended to metric names. See the [Metrics](#metrics) section below. | `""` |
 | `group_field` | The field name that is used to group metrics. See the [Metrics](#metrics) section below. | `""` |
 | `default_field` | The field name that is not included in metric names. See the [Metrics](#metrics) section below. | `""` |
-| `default_metric_values` | The default values used when the metrics are missing. | `{}` |
+| `default_metrics` | The default metrics posted when the corresponding metrics are missing. | `{}` |
 | `schedule_expression` | The schedule expression of the rule specifying the execution interval. Usually the execution interval is equal to the query interval. See [the document](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html) for the expression syntax. | |
 | `interval_in_minutes` | The interval of the query time range, in minutes. | |
 | `offset_in_minutes` | The offset of the query time range, in minutes. Usually this is the assumed maximum delay of logs. | `10` |
@@ -303,7 +303,7 @@ bar.failure	2	<timestamp>
 </tbody>
 </table>
 
-### Default metric values
+### Default metrics
 Logs:
 
 ``` json
@@ -338,10 +338,10 @@ Query result:
 <td>
 
 ``` hcl
-metric_name_prefix    = ""
-group_field           = "job_name"
-default_field         = ""
-default_metric_values = {}
+metric_name_prefix = ""
+group_field        = "job_name"
+default_field      = ""
+default_metrics    = {}
 ```
 
 </td>
@@ -357,10 +357,10 @@ foo.processed	30	<timestamp>
 <td>
 
 ``` hcl
-metric_name_prefix    = ""
-group_field           = "job_name"
-default_field         = ""
-default_metric_values = {
+metric_name_prefix = ""
+group_field        = "job_name"
+default_field      = ""
+default_metrics    = {
   "foo.processed" = 0
   "bar.processed" = 0
 }
@@ -380,10 +380,10 @@ bar.processed	0	<timestamp>
 <td>
 
 ``` hcl
-metric_name_prefix    = "my-batch-job"
-group_field           = "job_name"
-default_field         = "processed"
-default_metric_values = {
+metric_name_prefix = "my-batch-job"
+group_field        = "job_name"
+default_field      = "processed"
+default_metrics    = {
   "my-batch-job.foo" = 0
   "my-batch-job.bar" = 0
 }

--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -87,6 +87,7 @@ module "cw_logs_aggregator_rule_batch_jobs" {
 | `metric_name_prefix` | The common prefix appended to metric names. See the [Metrics](#metrics) section below. | `""` |
 | `group_field` | The field name that is used to group metrics. See the [Metrics](#metrics) section below. | `""` |
 | `default_field` | The field name that is not included in metric names. See the [Metrics](#metrics) section below. | `""` |
+| `default_metric_values` | The default values used when the metrics are missing. | `{}` |
 | `schedule_expression` | The schedule expression of the rule specifying the execution interval. Usually the execution interval is equal to the query interval. See [the document](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html) for the expression syntax. | |
 | `interval_in_minutes` | The interval of the query time range, in minutes. | |
 | `offset_in_minutes` | The offset of the query time range, in minutes. Usually this is the assumed maximum delay of logs. | `10` |
@@ -295,6 +296,64 @@ foo.failure	5	<timestamp>
 bar	8	<timestamp>
 bar.success	6	<timestamp>
 bar.failure	2	<timestamp>
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Default metric values
+Logs: (empty)
+
+Query:
+
+```
+stats sum(processed) as processed, sum(success) as success, sum(failure) as failure
+```
+
+Query result: (empty)
+
+<table>
+<thead>
+<tr>
+<th>Rule settings</th>
+<th>Metrics</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+``` hcl
+default_metric_values = {}
+```
+
+</td>
+<td>
+
+(empty)
+
+</td>
+</tr>
+<tr>
+<td>
+
+``` hcl
+default_metric_values = {
+  processed = 0
+  success = 0
+  failure = 0
+}
+```
+
+</td>
+<td>
+
+```
+processed	0	<timestamp>
+success	0	<timestamp>
+failure	0	<timestamp>
 ```
 
 </td>

--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -304,15 +304,27 @@ bar.failure	2	<timestamp>
 </table>
 
 ### Default metric values
-Logs: (empty)
+Logs:
+
+``` json
+{"job_name":"foo","processed":18}
+{"job_name":"foo","processed":12}
+```
 
 Query:
 
 ```
-stats sum(processed) as processed, sum(success) as success, sum(failure) as failure
+stats sum(processed) as processed by job_name
 ```
 
-Query result: (empty)
+Query result:
+
+```
+| job_name | processed |
+| ---------| --------- |
+| foo      |        30 |
+```
+
 
 <table>
 <thead>
@@ -326,13 +338,18 @@ Query result: (empty)
 <td>
 
 ``` hcl
+metric_name_prefix    = ""
+group_field           = "job_name"
+default_field         = ""
 default_metric_values = {}
 ```
 
 </td>
 <td>
 
-(empty)
+```
+foo.processed	30	<timestamp>
+```
 
 </td>
 </tr>
@@ -340,10 +357,12 @@ default_metric_values = {}
 <td>
 
 ``` hcl
+metric_name_prefix    = ""
+group_field           = "job_name"
+default_field         = ""
 default_metric_values = {
-  processed = 0
-  success = 0
-  failure = 0
+  "foo.processed" = 0
+  "bar.processed" = 0
 }
 ```
 
@@ -351,9 +370,31 @@ default_metric_values = {
 <td>
 
 ```
-processed	0	<timestamp>
-success	0	<timestamp>
-failure	0	<timestamp>
+foo.processed	30	<timestamp>
+bar.processed	0	<timestamp>
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+``` hcl
+metric_name_prefix    = "my-batch-job"
+group_field           = "job_name"
+default_field         = "processed"
+default_metric_values = {
+  "my-batch-job.foo" = 0
+  "my-batch-job.bar" = 0
+}
+```
+
+</td>
+<td>
+
+```
+my-batch-job.foo	30	<timestamp>
+my-batch-job.bar	0	<timestamp>
 ```
 
 </td>

--- a/cloudwatch-logs-aggregator/lambda/main.go
+++ b/cloudwatch-logs-aggregator/lambda/main.go
@@ -36,9 +36,10 @@ type Event struct {
 	IntervalInMinutes int64  `json:"interval_in_minutes"`
 	OffsetInMinutes   int64  `json:"offset_in_minutes"`
 
-	MetricNamePrefix string `json:"metric_name_prefix"`
-	GroupField       string `json:"group_field"`
-	DefaultField     string `json:"default_field"`
+	MetricNamePrefix    string             `json:"metric_name_prefix"`
+	GroupField          string             `json:"group_field"`
+	DefaultField        string             `json:"default_field"`
+	DefaultMetricValues map[string]float64 `json:"default_metric_values"`
 
 	ServiceName string `json:"service_name"`
 }
@@ -80,14 +81,22 @@ func HandleRequest(ctx context.Context, event Event) error {
 	}
 
 	cwLogsSvc := cloudwatchlogs.New(sess)
-	timeRange := GetQueryTimeRange(time.Now(), time.Duration(event.IntervalInMinutes)*time.Minute, time.Duration(event.OffsetInMinutes)*time.Minute)
+	timeRange := GetQueryTimeRange(
+		time.Now(),
+		time.Duration(event.IntervalInMinutes)*time.Minute,
+		time.Duration(event.OffsetInMinutes)*time.Minute,
+	)
 	result, err := RunQuery(ctx, requestLogger, cwLogsSvc, event.LogGroupName, event.Query, timeRange)
 	if err != nil {
 		requestLogger.Errorf("failed to query: %v", err)
 		return err
 	}
 
-	data, err := GenerateMetricData(requestLogger, result.Results, timeRange.StartTime, event.MetricNamePrefix, event.GroupField, event.DefaultField)
+	data, err := GenerateMetricData(
+		requestLogger,
+		result.Results, timeRange.StartTime,
+		event.MetricNamePrefix, event.GroupField, event.DefaultField, event.DefaultMetricValues,
+	)
 	if err != nil {
 		requestLogger.Errorf("failed to generate metric data: %v", err)
 		return err
@@ -185,7 +194,13 @@ type CWLogsService interface {
 	GetQueryResultsWithContext(ctx aws.Context, input *cloudwatchlogs.GetQueryResultsInput, opts ...request.Option) (*cloudwatchlogs.GetQueryResultsOutput, error)
 }
 
-func RunQuery(ctx context.Context, logger logrus.FieldLogger, svc CWLogsService, logGroupName, query string, timeRange *QueryTimeRange) (*cloudwatchlogs.GetQueryResultsOutput, error) {
+func RunQuery(
+	ctx context.Context,
+	logger logrus.FieldLogger,
+	svc CWLogsService,
+	logGroupName, query string,
+	timeRange *QueryTimeRange,
+) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	q, err := svc.StartQueryWithContext(ctx, &cloudwatchlogs.StartQueryInput{
 		LogGroupName: aws.String(logGroupName),
 		StartTime:    aws.Int64(timeRange.StartTime.Unix()),
@@ -264,9 +279,15 @@ func withFilterByTimeRange(query string, timeRange *QueryTimeRange) string {
 	return b.String()
 }
 
-func GenerateMetricData(logger logrus.FieldLogger, results [][]*cloudwatchlogs.ResultField, time time.Time, metricNamePrefix, groupField, defaultField string) ([]*mackerel.MetricValue, error) {
+func GenerateMetricData(
+	logger logrus.FieldLogger,
+	results [][]*cloudwatchlogs.ResultField,
+	time time.Time,
+	metricNamePrefix, groupField, defaultField string,
+	defaultMetricValues map[string]float64,
+) ([]*mackerel.MetricValue, error) {
 	if len(results) == 0 {
-		return nil, nil
+		return generateDefaultMetricData(time, defaultMetricValues, nil), nil
 	}
 	data := make([]*mackerel.MetricValue, 0, len(results)*len(results[0]))
 	seenMetricNames := make(map[string]struct{})
@@ -311,7 +332,8 @@ func GenerateMetricData(logger logrus.FieldLogger, results [][]*cloudwatchlogs.R
 			})
 		}
 	}
-	return data, nil
+	defaultData := generateDefaultMetricData(time, defaultMetricValues, seenMetricNames)
+	return append(data, defaultData...), nil
 }
 
 func joinMetricName(metricNamePrefix, groupName, name string, isDefaultField bool) string {
@@ -328,11 +350,37 @@ func joinMetricName(metricNamePrefix, groupName, name string, isDefaultField boo
 	return strings.Join(names, ".")
 }
 
+func generateDefaultMetricData(
+	time time.Time,
+	defaultMetricValues map[string]float64,
+	seenMetricNames map[string]struct{},
+) []*mackerel.MetricValue {
+	if len(defaultMetricValues) == 0 {
+		return nil
+	}
+	data := make([]*mackerel.MetricValue, 0, len(defaultMetricValues))
+	for metricName, value := range defaultMetricValues {
+		if _, seen := seenMetricNames[metricName]; !seen {
+			data = append(data, &mackerel.MetricValue{
+				Name:  metricName,
+				Time:  time.Unix(),
+				Value: value,
+			})
+		}
+	}
+	return data
+}
+
 type MackerelClient interface {
 	PostServiceMetricValues(serviceName string, metricValues []*mackerel.MetricValue) error
 }
 
-func PostMetricData(logger logrus.FieldLogger, client MackerelClient, serviceName string, data []*mackerel.MetricValue) error {
+func PostMetricData(
+	logger logrus.FieldLogger,
+	client MackerelClient,
+	serviceName string,
+	data []*mackerel.MetricValue,
+) error {
 	logger.Debug("posting metric data")
 	err := client.PostServiceMetricValues(serviceName, data)
 	if err == nil {

--- a/cloudwatch-logs-aggregator/lambda/main_test.go
+++ b/cloudwatch-logs-aggregator/lambda/main_test.go
@@ -401,11 +401,20 @@ func TestRunQuery_stops_query_if_canceled(t *testing.T) {
 	assert.EqualError(t, err, ctx.Err().Error())
 }
 
+func getMetricValue(data []*mackerel.MetricValue, name string) *mackerel.MetricValue {
+	for _, v := range data {
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
 func TestGenerateMetricData_returns_empty_data_if_result_has_no_rows(t *testing.T) {
 	results := [][]*cloudwatchlogs.ResultField{}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "", "", "")
+	data, err := GenerateMetricData(logger, results, time, "", "", "", nil)
 	assert.NoError(t, err)
 	assert.Len(t, data, 0)
 }
@@ -429,24 +438,24 @@ func TestGenerateMetricData_generates_metric_data_to_post(t *testing.T) {
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "", "", "")
+	data, err := GenerateMetricData(logger, results, time, "", "", "", nil)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 3) {
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "xxx",
 			Time:  time.Unix(),
 			Value: 12.3,
-		}, *data[0])
+		}, *getMetricValue(data, "xxx"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "yyy",
 			Time:  time.Unix(),
 			Value: 45.6,
-		}, *data[1])
+		}, *getMetricValue(data, "yyy"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "zzz",
 			Time:  time.Unix(),
 			Value: 78.9,
-		}, *data[2])
+		}, *getMetricValue(data, "zzz"))
 	}
 }
 
@@ -469,24 +478,24 @@ func TestGenerateMetricData_appends_metric_name_prefix_if_exists(t *testing.T) {
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "foobar", "", "")
+	data, err := GenerateMetricData(logger, results, time, "foobar", "", "", nil)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 3) {
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.xxx",
 			Time:  time.Unix(),
 			Value: 12.3,
-		}, *data[0])
+		}, *getMetricValue(data, "foobar.xxx"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.yyy",
 			Time:  time.Unix(),
 			Value: 45.6,
-		}, *data[1])
+		}, *getMetricValue(data, "foobar.yyy"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.zzz",
 			Time:  time.Unix(),
 			Value: 78.9,
-		}, *data[2])
+		}, *getMetricValue(data, "foobar.zzz"))
 	}
 }
 
@@ -509,24 +518,24 @@ func TestGenerateMetricData_does_not_include_default_field_in_metric_names(t *te
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "foobar", "", "yyy")
+	data, err := GenerateMetricData(logger, results, time, "foobar", "", "yyy", nil)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 3) {
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.xxx",
 			Time:  time.Unix(),
 			Value: 12.3,
-		}, *data[0])
+		}, *getMetricValue(data, "foobar.xxx"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar",
 			Time:  time.Unix(),
 			Value: 45.6,
-		}, *data[1])
+		}, *getMetricValue(data, "foobar"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.zzz",
 			Time:  time.Unix(),
 			Value: 78.9,
-		}, *data[2])
+		}, *getMetricValue(data, "foobar.zzz"))
 	}
 }
 
@@ -577,39 +586,76 @@ func TestGenerateMetricData_groups_metrics_by_group_field(t *testing.T) {
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "foobar", "group", "processed")
+	data, err := GenerateMetricData(logger, results, time, "foobar", "group", "processed", nil)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 6) {
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.xxx",
 			Time:  time.Unix(),
 			Value: 12.3,
-		}, *data[0])
+		}, *getMetricValue(data, "foobar.xxx"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.xxx.error",
 			Time:  time.Unix(),
 			Value: 0.123,
-		}, *data[1])
+		}, *getMetricValue(data, "foobar.xxx.error"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.yyy",
 			Time:  time.Unix(),
 			Value: 45.6,
-		}, *data[2])
+		}, *getMetricValue(data, "foobar.yyy"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.yyy.error",
 			Time:  time.Unix(),
 			Value: 0.456,
-		}, *data[3])
+		}, *getMetricValue(data, "foobar.yyy.error"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.zzz",
 			Time:  time.Unix(),
 			Value: 78.9,
-		}, *data[4])
+		}, *getMetricValue(data, "foobar.zzz"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "foobar.zzz.error",
 			Time:  time.Unix(),
 			Value: 0.789,
-		}, *data[5])
+		}, *getMetricValue(data, "foobar.zzz.error"))
+	}
+}
+
+func TestGenerateMetricData_use_default_values_for_missing_metrics(t *testing.T) {
+	results := [][]*cloudwatchlogs.ResultField{
+		{
+			{
+				Field: aws.String("xxx"),
+				Value: aws.String("12.3"),
+			},
+		},
+	}
+	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
+	defaultMetricValues := map[string]float64{
+		"xxx": 0.0,
+		"yyy": 0.0,
+		"zzz": 1.0,
+	}
+
+	data, err := GenerateMetricData(logger, results, time, "", "", "", defaultMetricValues)
+	assert.NoError(t, err)
+	if assert.Len(t, data, 3) {
+		assert.Equal(t, mackerel.MetricValue{
+			Name:  "xxx",
+			Time:  time.Unix(),
+			Value: 12.3,
+		}, *getMetricValue(data, "xxx"))
+		assert.Equal(t, mackerel.MetricValue{
+			Name:  "yyy",
+			Time:  time.Unix(),
+			Value: 0.0,
+		}, *getMetricValue(data, "yyy"))
+		assert.Equal(t, mackerel.MetricValue{
+			Name:  "zzz",
+			Time:  time.Unix(),
+			Value: 1.0,
+		}, *getMetricValue(data, "zzz"))
 	}
 }
 
@@ -632,19 +678,19 @@ func TestGenerateMetricData_skips_fields_that_could_not_be_parsed(t *testing.T) 
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "", "", "")
+	data, err := GenerateMetricData(logger, results, time, "", "", "", nil)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 2) {
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "xxx",
 			Time:  time.Unix(),
 			Value: 12.3,
-		}, *data[0])
+		}, *getMetricValue(data, "xxx"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "zzz",
 			Time:  time.Unix(),
 			Value: 78.9,
-		}, *data[1])
+		}, *getMetricValue(data, "zzz"))
 	}
 }
 
@@ -667,19 +713,19 @@ func TestGenerateMetricData_skips_fields_that_have_empty_metric_name(t *testing.
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "", "", "yyy")
+	data, err := GenerateMetricData(logger, results, time, "", "", "yyy", nil)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 2) {
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "xxx",
 			Time:  time.Unix(),
 			Value: 12.3,
-		}, *data[0])
+		}, *getMetricValue(data, "xxx"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "zzz",
 			Time:  time.Unix(),
 			Value: 78.9,
-		}, *data[1])
+		}, *getMetricValue(data, "zzz"))
 	}
 }
 
@@ -716,24 +762,24 @@ func TestGenerateMetricData_skips_fields_that_have_duplicate_metric_name(t *test
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
 
-	data, err := GenerateMetricData(logger, results, time, "", "", "")
+	data, err := GenerateMetricData(logger, results, time, "", "", "", nil)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 3) {
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "xxx",
 			Time:  time.Unix(),
 			Value: 12.3,
-		}, *data[0])
+		}, *getMetricValue(data, "xxx"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "yyy",
 			Time:  time.Unix(),
 			Value: 45.6,
-		}, *data[1])
+		}, *getMetricValue(data, "yyy"))
 		assert.Equal(t, mackerel.MetricValue{
 			Name:  "zzz",
 			Time:  time.Unix(),
 			Value: 78.9,
-		}, *data[2])
+		}, *getMetricValue(data, "zzz"))
 	}
 }
 

--- a/cloudwatch-logs-aggregator/lambda/main_test.go
+++ b/cloudwatch-logs-aggregator/lambda/main_test.go
@@ -632,13 +632,13 @@ func TestGenerateMetricData_use_default_values_for_missing_metrics(t *testing.T)
 		},
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
-	defaultMetricValues := map[string]float64{
+	defaultMetrics := map[string]float64{
 		"xxx": 0.0,
 		"yyy": 0.0,
 		"zzz": 1.0,
 	}
 
-	data, err := GenerateMetricData(logger, results, time, "", "", "", defaultMetricValues)
+	data, err := GenerateMetricData(logger, results, time, "", "", "", defaultMetrics)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 3) {
 		assert.Equal(t, mackerel.MetricValue{
@@ -662,12 +662,12 @@ func TestGenerateMetricData_use_default_values_for_missing_metrics(t *testing.T)
 func TestGenerateMetricData_use_all_default_values_if_result_has_no_rows(t *testing.T) {
 	results := [][]*cloudwatchlogs.ResultField{}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
-	defaultMetricValues := map[string]float64{
+	defaultMetrics := map[string]float64{
 		"xxx": 0.0,
 		"yyy": 0.0,
 	}
 
-	data, err := GenerateMetricData(logger, results, time, "", "", "", defaultMetricValues)
+	data, err := GenerateMetricData(logger, results, time, "", "", "", defaultMetrics)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 2) {
 		assert.Equal(t, mackerel.MetricValue{
@@ -693,12 +693,12 @@ func TestGenerateMetricData_default_metric_names_are_compared_with_processed_met
 		},
 	}
 	time := time.Date(2021, time.June, 6, 12, 20, 0, 0, time.UTC)
-	defaultMetricValues := map[string]float64{
+	defaultMetrics := map[string]float64{
 		"foobar":     0.0,
 		"foobar.yyy": 0.0,
 	}
 
-	data, err := GenerateMetricData(logger, results, time, "foobar", "", "xxx", defaultMetricValues)
+	data, err := GenerateMetricData(logger, results, time, "foobar", "", "xxx", defaultMetrics)
 	assert.NoError(t, err)
 	if assert.Len(t, data, 2) {
 		assert.Equal(t, mackerel.MetricValue{

--- a/cloudwatch-logs-aggregator/rule/main.tf
+++ b/cloudwatch-logs-aggregator/rule/main.tf
@@ -24,10 +24,10 @@ resource "aws_cloudwatch_event_target" "this" {
     interval_in_minutes = var.interval_in_minutes
     offset_in_minutes   = var.offset_in_minutes
 
-    metric_name_prefix    = var.metric_name_prefix
-    group_field           = var.group_field
-    default_field         = var.default_field
-    default_metric_values = var.default_metric_values
+    metric_name_prefix = var.metric_name_prefix
+    group_field        = var.group_field
+    default_field      = var.default_field
+    default_metrics    = var.default_metrics
 
     service_name = var.service_name
   })

--- a/cloudwatch-logs-aggregator/rule/main.tf
+++ b/cloudwatch-logs-aggregator/rule/main.tf
@@ -24,9 +24,10 @@ resource "aws_cloudwatch_event_target" "this" {
     interval_in_minutes = var.interval_in_minutes
     offset_in_minutes   = var.offset_in_minutes
 
-    metric_name_prefix = var.metric_name_prefix
-    group_field        = var.group_field
-    default_field      = var.default_field
+    metric_name_prefix    = var.metric_name_prefix
+    group_field           = var.group_field
+    default_field         = var.default_field
+    default_metric_values = var.default_metric_values
 
     service_name = var.service_name
   })

--- a/cloudwatch-logs-aggregator/rule/variables.tf
+++ b/cloudwatch-logs-aggregator/rule/variables.tf
@@ -94,8 +94,8 @@ variable "default_field" {
   default     = ""
 }
 
-variable "default_metric_values" {
-  description = "The default values used when the metrics are missing."
+variable "default_metrics" {
+  description = "The default metrics posted when the corresponding metrics are missing."
   type        = map(number)
   default     = {}
 }

--- a/cloudwatch-logs-aggregator/rule/variables.tf
+++ b/cloudwatch-logs-aggregator/rule/variables.tf
@@ -94,6 +94,12 @@ variable "default_field" {
   default     = ""
 }
 
+variable "default_metric_values" {
+  description = "The default values used when the metrics are missing."
+  type        = map(number)
+  default     = {}
+}
+
 variable "service_name" {
   description = "The name of the service on Mackerel to which metrics are posted."
   type        = string

--- a/cloudwatch-logs-aggregator/rule/variables.tf
+++ b/cloudwatch-logs-aggregator/rule/variables.tf
@@ -95,7 +95,7 @@ variable "default_field" {
 }
 
 variable "default_metrics" {
-  description = "The default metrics posted when the corresponding metrics are missing."
+  description = "The default metric values posted when the corresponding values are missing in query results."
   type        = map(number)
   default     = {}
 }


### PR DESCRIPTION
This PR adds `default_metrics` parameter to fill metrics when a query result does not contain corresponding values.