### PR TITLE
Make it possible to add tags to the Lambda to be created

### DIFF
--- a/cloudwatch-logs-aggregator/lambda/main.tf
+++ b/cloudwatch-logs-aggregator/lambda/main.tf
@@ -63,6 +63,7 @@ resource "aws_lambda_function" "this" {
   source_code_hash = filebase64sha256(local.function_zip)
 
   depends_on = [aws_cloudwatch_log_group.this]
+  tags       = var.tags
 }
 
 resource "aws_cloudwatch_log_group" "this" {

--- a/cloudwatch-logs-aggregator/lambda/variables.tf
+++ b/cloudwatch-logs-aggregator/lambda/variables.tf
@@ -32,3 +32,9 @@ variable "log_retention_in_days" {
   type        = number
   default     = 0
 }
+
+variable "tags" {
+  description = "Tags of the Lambda function"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
## Why

When using the terraform module provided here, there was no way to add tags other than default tags.
Since that would be inconvenient, I made it possible to receive tags as a variable and pass it to the lambda function.

## How

A tag is prepared as an argument, and it is used where lambda is created in the module as it is.

## operation check

I wrote the following terraform for Lambda that has already been tagged from the console and confirmed that the diff disappeared.

```
module "cw_logs_aggregator_lambda" {
  #source = "github.com/mackerelio-labs/mackerel-monitoring-modules//cloudwatch-
logs-aggregator/lambda?ref=v0.1.3"
  source = "<path-to-local-mackerel-monitoring-modules>/cloudwatch-logs-aggregator/lambda"
  function_name = "function"
  iam_role_name = "function-role"
  tags = {
   keyA = "valueA"
  }
}
```