### PR TITLE
Migrate go1.x to provided.al2

### DIFF
--- a/cloudwatch-logs-aggregator/lambda/Makefile
+++ b/cloudwatch-logs-aggregator/lambda/Makefile
@@ -1,7 +1,8 @@
 .PHONY: build
 build:
-	GOOS=linux GOARCH=amd64 go build -o main
-	zip function.zip main
+	GOOS=linux GOARCH=amd64 go build -o bootstrap
+	zip function.zip bootstrap
+	rm bootstrap
 
 .PHONY: test
 test:

--- a/cloudwatch-logs-aggregator/lambda/main.tf
+++ b/cloudwatch-logs-aggregator/lambda/main.tf
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "this" {
   description   = "created by mackerel-monitoring-modules"
   role          = aws_iam_role.this.arn
 
-  runtime     = "go1.x"
+  runtime     = "provided.al2"
   memory_size = var.memory_size_in_mb
   timeout     = var.timeout_in_seconds
   filename    = local.function_zip


### PR DESCRIPTION
Hi, I want to migrate `go1.x` to `provided.al2`. Because `go1.x` is based on the Amazon Linux AMI (AL1).

Lambda will continue to support the Go 1.x managed runtime until maintenance support for the Amazon Linux AMI ends on December 31, 2023.

ref: https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html

And, I want to rename the executable to `bootstrap`. 

> You can implement an AWS Lambda runtime in any programming language. A runtime is a program that runs a Lambda function's handler method when the function is invoked. You can include a runtime in your function's deployment package as an executable file named bootstrap.

ref: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html