### PR TITLE
[cloudwatch-logs-aggregator] BREAKING CHANGE: Remove AWS provider block from modules

### DIFF
--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -83,7 +83,6 @@ module "cw_logs_aggregator_rule_batch_jobs" {
 ### Variables
 | Name | Description | Default |
 | --- | --- | --- |
-| `region` | The AWS region in which the resources are created. | |
 | `rule_name` | The name of the EventBridge rule. | |
 | `function_arn` | The ARN of the target Lambda function. | |
 | `state` | Whether the rules is enabled or not. See [the document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#state) | `"ENABLED"` |

--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -86,7 +86,7 @@ module "cw_logs_aggregator_rule_batch_jobs" {
 | `region` | The AWS region in which the resources are created. | |
 | `rule_name` | The name of the EventBridge rule. | |
 | `function_arn` | The ARN of the target Lambda function. | |
-| `is_enabled` | Whether the rules is enabled or not. | `true` |
+| `state` | Whether the rules is enabled or not. See [the document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#state) | `"ENABLED"` |
 | `api_key_name` | The name of the parameter of Parameter Store which stores the Mackerel API key. It is recommended to store the API key as a secure string. | |
 | `service_name` | The name of the service on Mackerel to which metrics are posted. | |
 | `log_group_name` | The name of the log group to be aggregated. | |

--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -27,17 +27,19 @@ The cloudwatch-logs-aggregator-lambda module manages a Lambda function that runs
 
 ### Example
 ``` hcl
+provider "aws" {
+  region = "ap-northeast-1"
+  // >= 5.27.0 is required
+}
+
 module "cw_logs_aggregator_lambda" {
   source = "github.com/mackerelio-labs/mackerel-monitoring-modules//cloudwatch-logs-aggregator/lambda?ref=v0.2.2"
-
-  region = "ap-northeast-1"
 }
 ```
 
 ### Variables
 | Name | Description | Default |
 | --- | --- | --- |
-| `region` | The AWS region in which the resources are created. | |
 | `iam_role_name` | The name of the Lambda function's execution role. | `"mackerel-cloudwatch-logs-aggregator-lambda"` |
 | `function_name` | The name of the Lambda function. | `"mackerel-cloudwatch-logs-aggregator"` |
 | `memory_size_in_mb` | The memory size of the Lambda function, in megabytes. | `128` |
@@ -52,10 +54,14 @@ You can attach multiple rules for a signle Lambda function.
 
 ### Example
 ``` hcl
+provider "aws" {
+  region = "ap-northeast-1"
+  // >= 5.27.0 is required
+}
+
 module "cw_logs_aggregator_rule_batch_jobs" {
   source = "github.com/mackerelio-labs/mackerel-monitoring-modules//cloudwatch-logs-aggregator/rule?ref=v0.2.2"
 
-  region       = "ap-northeast-1"
   rule_name    = "mackerel-cloudwatch-logs-aggregator-batch-jobs"
   function_arn = module.cw_logs_aggregator_lambda.function_arn
 

--- a/cloudwatch-logs-aggregator/lambda/main.tf
+++ b/cloudwatch-logs-aggregator/lambda/main.tf
@@ -1,5 +1,10 @@
-provider "aws" {
-  region = var.region
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.27.0"
+    }
+  }
 }
 
 resource "aws_iam_role" "this" {

--- a/cloudwatch-logs-aggregator/lambda/variables.tf
+++ b/cloudwatch-logs-aggregator/lambda/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  description = "The AWS region in which the resources are created."
-  type        = string
-}
-
 variable "iam_role_name" {
   description = "The name of the Lambda function's execution role."
   type        = string

--- a/cloudwatch-logs-aggregator/rule/main.tf
+++ b/cloudwatch-logs-aggregator/rule/main.tf
@@ -6,9 +6,6 @@ terraform {
     }
   }
 }
-provider "aws" {
-  region = var.region
-}
 
 resource "aws_cloudwatch_event_rule" "this" {
   name                = var.rule_name

--- a/cloudwatch-logs-aggregator/rule/variables.tf
+++ b/cloudwatch-logs-aggregator/rule/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  description = "The AWS region in which the resources are created."
-  type        = string
-}
-
 variable "rule_name" {
   description = "The name of the EventBridge rule."
   type        = string


### PR DESCRIPTION
- https://github.com/mackerelio-labs/mackerel-monitoring-modules/issues/23