### PR TITLE
[cloudwatch-logs-aggregator] BREAKING CHANGE: Rollback breaking changes for is_enabled variable

### DIFF
--- a/cloudwatch-logs-aggregator/README.md
+++ b/cloudwatch-logs-aggregator/README.md
@@ -85,7 +85,7 @@ module "cw_logs_aggregator_rule_batch_jobs" {
 | --- | --- | --- |
 | `rule_name` | The name of the EventBridge rule. | |
 | `function_arn` | The ARN of the target Lambda function. | |
-| `state` | Whether the rules is enabled or not. See [the document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#state) | `"ENABLED"` |
+| `is_enabled` | Whether the rules is enabled or not. | `true` |
 | `api_key_name` | The name of the parameter of Parameter Store which stores the Mackerel API key. It is recommended to store the API key as a secure string. | |
 | `service_name` | The name of the service on Mackerel to which metrics are posted. | |
 | `log_group_name` | The name of the log group to be aggregated. | |

--- a/cloudwatch-logs-aggregator/rule/main.tf
+++ b/cloudwatch-logs-aggregator/rule/main.tf
@@ -10,7 +10,7 @@ terraform {
 resource "aws_cloudwatch_event_rule" "this" {
   name                = var.rule_name
   description         = "created by mackerel-monitoring-modules"
-  state               = var.state
+  state               = var.is_enabled ? "ENABLED" : "DISABLED"
   schedule_expression = var.schedule_expression
 }
 

--- a/cloudwatch-logs-aggregator/rule/variables.tf
+++ b/cloudwatch-logs-aggregator/rule/variables.tf
@@ -3,10 +3,10 @@ variable "rule_name" {
   type        = string
 }
 
-variable "state" {
+variable "is_enabled" {
   description = "Whether the rules is enabled or not."
-  type        = string
-  default     = "ENABLED"
+  type        = bool
+  default     = true
 }
 
 variable "schedule_expression" {


### PR DESCRIPTION
[v0.2.2](https://github.com/mackerelio-labs/mackerel-monitoring-modules/releases/tag/v0.2.2) release contains a breaking change about `is_enabled` variable in spite of a patch version update. Since this change is undesirable considering the abstractness of the module, we made the following changes:

- restore `is_enabled` (boolean) variable to specify whether the rule is enabled
  - If it is true/false, pass `"ENABLED"`/`"DISABLED"` for state of `aws_cloudwatch_event_rule`
- remove `state` variable instead (BREAKING CHANGE for v0.2.2 users, but not so for users before one)