### PR TITLE
[cloudwatch-logs-aggregator] replace deprecated inline_policy block of aws_iam_role resource

### DIFF
--- a/cloudwatch-logs-aggregator/lambda/main.tf
+++ b/cloudwatch-logs-aggregator/lambda/main.tf
@@ -25,28 +25,29 @@ resource "aws_iam_role" "this" {
   })
 
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+}
 
-  inline_policy {
-    name = "cloudwatch-logs-aggregator-lambda"
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect   = "Allow"
-          Action   = ["ssm:GetParameter"]
-          Resource = "*"
-        },
-        {
-          Effect = "Allow"
-          Action = [
-            "logs:StartQuery",
-            "logs:StopQuery",
-            "logs:GetQueryResults",
-          ]
-          Resource = "*"
-        },
-      ]
-    })
+resource "aws_iam_role_policy" "this" {
+  role   = aws_iam_role.this.id
+  name   = "cloudwatch-logs-aggregator-lambda"
+  policy = data.aws_iam_policy_document.this.json
+}
+
+data "aws_iam_policy_document" "this" {
+  version = "2012-10-17"
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:StartQuery",
+      "logs:StopQuery",
+      "logs:GetQueryResults",
+    ]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
## Issue

- #28 

## Description

I replaced inline_policy block of aws_iam_role resource, which is deprecated from terraform-provider-aws [v5.68.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.68.0), to aws_iam_role_policy resource.

Another candidate for replacement was aws_iam_role_policies_exclusive, but I did not choose it. This resource is not provided in terraform-provider-aws prior to v5.68.0. I think that exclusively inline-policy management is not particularly necessary in our case. If using aws_iam_role_policies_exclusive, you have to bump up their terraform-provider-aws to latest.

## Test

```diff
 module "cw_logs_aggregator_lambda" {
-  source = "github.com/mackerelio-labs/mackerel-monitoring-modules//cloudwatch-logs-aggregator/lambda?ref=v0.3.0"
+  source = "github.com/mackerelio-labs/mackerel-monitoring-modules//cloudwatch-logs-aggregator/lambda?ref=7ef608"

   ...
 }
```


```console
$ terraform plan
...
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # module.sendgrid_webhook_logs_aggregator.module.cw_logs_aggregator_lambda.aws_iam_role_policy.this will be created
  + resource "aws_iam_role_policy" "this" {
      + id          = (known after apply)
      + name        = "cloudwatch-logs-aggregator-lambda"
      + name_prefix = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "ssm:GetParameter"
                      + Effect   = "Allow"
                      + Resource = "*"
                    },
                  + {
                      + Action   = [
                          + "logs:StopQuery",
                          + "logs:StartQuery",
                          + "logs:GetQueryResults",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role        = "sendgrid-webhook-logs-aggregator-lambda"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
...
```
<img width="1046" alt="スクリーンショット 2024-10-04 17 06 23" src="https://github.com/user-attachments/assets/3c0cace6-5e8b-4e53-a467-ce403c382120">

